### PR TITLE
Add core trip domain models

### DIFF
--- a/lib/models/geo_point.dart
+++ b/lib/models/geo_point.dart
@@ -1,0 +1,47 @@
+/// Represents a geographic coordinate in decimal degrees.
+///
+/// The [latitude] must be between -90 and 90 degrees, and the [longitude]
+/// between -180 and 180 degrees. Values outside of this range will throw an
+/// [ArgumentError] to catch issues early in development.
+class GeoPoint {
+  const GeoPoint({required this.latitude, required this.longitude})
+      : assert(latitude >= -90 && latitude <= 90,
+            'Latitude must be between -90 and 90.'),
+        assert(longitude >= -180 && longitude <= 180,
+            'Longitude must be between -180 and 180.');
+
+  final double latitude;
+  final double longitude;
+
+  GeoPoint copyWith({double? latitude, double? longitude}) {
+    return GeoPoint(
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'latitude': latitude,
+        'longitude': longitude,
+      };
+
+  factory GeoPoint.fromJson(Map<String, dynamic> json) {
+    return GeoPoint(
+      latitude: (json['latitude'] as num).toDouble(),
+      longitude: (json['longitude'] as num).toDouble(),
+    );
+  }
+
+  @override
+  String toString() => 'GeoPoint(lat: $latitude, lng: $longitude)';
+
+  @override
+  bool operator ==(Object other) {
+    return other is GeoPoint &&
+        other.latitude == latitude &&
+        other.longitude == longitude;
+  }
+
+  @override
+  int get hashCode => Object.hash(latitude, longitude);
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,0 +1,4 @@
+export 'geo_point.dart';
+export 'saved_location.dart';
+export 'trip.dart';
+export 'vehicle.dart';

--- a/lib/models/saved_location.dart
+++ b/lib/models/saved_location.dart
@@ -1,0 +1,78 @@
+import 'geo_point.dart';
+
+/// Represents a location saved by the user for quick reuse when logging trips.
+class SavedLocation {
+  const SavedLocation({
+    required this.id,
+    required this.label,
+    required this.position,
+    this.addressLine,
+    this.notes,
+  });
+
+  /// Unique identifier for persistence. Can be generated with UUIDs.
+  final String id;
+
+  /// User facing label such as "Home" or "Client HQ".
+  final String label;
+
+  /// Geographic coordinates of the saved place.
+  final GeoPoint position;
+
+  /// Optional human readable address to surface in the UI.
+  final String? addressLine;
+
+  /// Optional notes about the location.
+  final String? notes;
+
+  SavedLocation copyWith({
+    String? id,
+    String? label,
+    GeoPoint? position,
+    String? addressLine,
+    String? notes,
+  }) {
+    return SavedLocation(
+      id: id ?? this.id,
+      label: label ?? this.label,
+      position: position ?? this.position,
+      addressLine: addressLine ?? this.addressLine,
+      notes: notes ?? this.notes,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+        'position': position.toJson(),
+        'addressLine': addressLine,
+        'notes': notes,
+      };
+
+  factory SavedLocation.fromJson(Map<String, dynamic> json) {
+    return SavedLocation(
+      id: json['id'] as String,
+      label: json['label'] as String,
+      position: GeoPoint.fromJson(json['position'] as Map<String, dynamic>),
+      addressLine: json['addressLine'] as String?,
+      notes: json['notes'] as String?,
+    );
+  }
+
+  @override
+  String toString() => 'SavedLocation(label: $label, position: $position)';
+
+  @override
+  bool operator ==(Object other) {
+    return other is SavedLocation &&
+        other.id == id &&
+        other.label == label &&
+        other.position == position &&
+        other.addressLine == addressLine &&
+        other.notes == notes;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, label, position, addressLine, notes);
+}

--- a/lib/models/trip.dart
+++ b/lib/models/trip.dart
@@ -1,0 +1,191 @@
+import 'geo_point.dart';
+import 'saved_location.dart';
+import 'vehicle.dart';
+
+/// Core domain entity capturing a mileage trip.
+class Trip {
+  const Trip({
+    required this.id,
+    required this.startTime,
+    required this.endTime,
+    required this.startPosition,
+    required this.endPosition,
+    required this.startOdometer,
+    required this.endOdometer,
+    required this.vehicleId,
+    this.vehicle,
+    this.startLocationId,
+    this.endLocationId,
+    this.startLocation,
+    this.endLocation,
+    this.notes,
+    this.tags = const <String>[],
+  }) : assert(endTime.isAfter(startTime), 'End time must be after start time.');
+
+  final String id;
+  final DateTime startTime;
+  final DateTime endTime;
+  final GeoPoint startPosition;
+  final GeoPoint endPosition;
+  final double startOdometer;
+  final double endOdometer;
+  final String vehicleId;
+
+  /// Optional vehicle snapshot at the time of the trip.
+  final Vehicle? vehicle;
+
+  /// Link to saved locations for quick reuse in the UI.
+  final String? startLocationId;
+  final String? endLocationId;
+
+  /// Optional denormalised saved location references.
+  final SavedLocation? startLocation;
+  final SavedLocation? endLocation;
+
+  final String? notes;
+
+  /// Free form tags (e.g. "Personal", "Client A") until tagging entity exists.
+  final List<String> tags;
+
+  Duration get duration => endTime.difference(startTime);
+
+  double get distance => (endOdometer - startOdometer).clamp(0, double.infinity);
+
+  Trip copyWith({
+    String? id,
+    DateTime? startTime,
+    DateTime? endTime,
+    GeoPoint? startPosition,
+    GeoPoint? endPosition,
+    double? startOdometer,
+    double? endOdometer,
+    String? vehicleId,
+    Vehicle? vehicle,
+    String? startLocationId,
+    String? endLocationId,
+    SavedLocation? startLocation,
+    SavedLocation? endLocation,
+    String? notes,
+    List<String>? tags,
+  }) {
+    return Trip(
+      id: id ?? this.id,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      startPosition: startPosition ?? this.startPosition,
+      endPosition: endPosition ?? this.endPosition,
+      startOdometer: startOdometer ?? this.startOdometer,
+      endOdometer: endOdometer ?? this.endOdometer,
+      vehicleId: vehicleId ?? this.vehicleId,
+      vehicle: vehicle ?? this.vehicle,
+      startLocationId: startLocationId ?? this.startLocationId,
+      endLocationId: endLocationId ?? this.endLocationId,
+      startLocation: startLocation ?? this.startLocation,
+      endLocation: endLocation ?? this.endLocation,
+      notes: notes ?? this.notes,
+      tags: tags ?? this.tags,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'startTime': startTime.toIso8601String(),
+        'endTime': endTime.toIso8601String(),
+        'startPosition': startPosition.toJson(),
+        'endPosition': endPosition.toJson(),
+        'startOdometer': startOdometer,
+        'endOdometer': endOdometer,
+        'vehicleId': vehicleId,
+        'vehicle': vehicle?.toJson(),
+        'startLocationId': startLocationId,
+        'endLocationId': endLocationId,
+        'notes': notes,
+        'tags': tags,
+        'startLocation': startLocation?.toJson(),
+        'endLocation': endLocation?.toJson(),
+      };
+
+  factory Trip.fromJson(Map<String, dynamic> json) {
+    return Trip(
+      id: json['id'] as String,
+      startTime: DateTime.parse(json['startTime'] as String),
+      endTime: DateTime.parse(json['endTime'] as String),
+      startPosition:
+          GeoPoint.fromJson(json['startPosition'] as Map<String, dynamic>),
+      endPosition: GeoPoint.fromJson(json['endPosition'] as Map<String, dynamic>),
+      startOdometer: (json['startOdometer'] as num).toDouble(),
+      endOdometer: (json['endOdometer'] as num).toDouble(),
+      vehicleId: json['vehicleId'] as String,
+      vehicle: json['vehicle'] == null
+          ? null
+          : Vehicle.fromJson(json['vehicle'] as Map<String, dynamic>),
+      startLocationId: json['startLocationId'] as String?,
+      endLocationId: json['endLocationId'] as String?,
+      notes: json['notes'] as String?,
+      tags: (json['tags'] as List<dynamic>? ?? const <dynamic>[])
+          .cast<String>(),
+      startLocation: json['startLocation'] == null
+          ? null
+          : SavedLocation.fromJson(
+              json['startLocation'] as Map<String, dynamic>),
+      endLocation: json['endLocation'] == null
+          ? null
+          : SavedLocation.fromJson(
+              json['endLocation'] as Map<String, dynamic>),
+    );
+  }
+
+  bool get hasSavedLocations =>
+      startLocationId != null || endLocationId != null;
+
+  bool get hasVehicleSnapshot => vehicle != null;
+
+  @override
+  String toString() =>
+      'Trip($startTime -> $endTime, vehicle: $vehicleId, distance: $distance)';
+
+  @override
+  bool operator ==(Object other) {
+    return other is Trip &&
+        other.id == id &&
+        other.startTime == startTime &&
+        other.endTime == endTime &&
+        other.startPosition == startPosition &&
+        other.endPosition == endPosition &&
+        other.startOdometer == startOdometer &&
+        other.endOdometer == endOdometer &&
+        other.vehicleId == vehicleId &&
+        other.startLocationId == startLocationId &&
+        other.endLocationId == endLocationId &&
+        other.startLocation == startLocation &&
+        other.endLocation == endLocation &&
+        other.notes == notes &&
+        _listEquals(other.tags, tags);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      id,
+      startTime,
+      endTime,
+      startPosition,
+      endPosition,
+      startOdometer,
+      endOdometer,
+      vehicleId,
+      startLocationId,
+      endLocationId,
+      startLocation,
+      endLocation,
+      notes,
+      Object.hashAll(tags));
+}
+
+bool _listEquals<T>(List<T> a, List<T> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/lib/models/vehicle.dart
+++ b/lib/models/vehicle.dart
@@ -1,0 +1,92 @@
+/// Representation of a vehicle that can be associated with a trip.
+class Vehicle {
+  const Vehicle({
+    required this.id,
+    required this.displayName,
+    this.make,
+    this.model,
+    this.year,
+    this.licensePlate,
+    this.defaultOdometer,
+    this.isActive = false,
+  });
+
+  final String id;
+  final String displayName;
+  final String? make;
+  final String? model;
+  final int? year;
+  final String? licensePlate;
+
+  /// Optional odometer value that will pre-fill a new trip.
+  final double? defaultOdometer;
+
+  /// Whether this vehicle is the currently active one for quick selection.
+  final bool isActive;
+
+  Vehicle copyWith({
+    String? id,
+    String? displayName,
+    String? make,
+    String? model,
+    int? year,
+    String? licensePlate,
+    double? defaultOdometer,
+    bool? isActive,
+  }) {
+    return Vehicle(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      make: make ?? this.make,
+      model: model ?? this.model,
+      year: year ?? this.year,
+      licensePlate: licensePlate ?? this.licensePlate,
+      defaultOdometer: defaultOdometer ?? this.defaultOdometer,
+      isActive: isActive ?? this.isActive,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'displayName': displayName,
+        'make': make,
+        'model': model,
+        'year': year,
+        'licensePlate': licensePlate,
+        'defaultOdometer': defaultOdometer,
+        'isActive': isActive,
+      };
+
+  factory Vehicle.fromJson(Map<String, dynamic> json) {
+    return Vehicle(
+      id: json['id'] as String,
+      displayName: json['displayName'] as String,
+      make: json['make'] as String?,
+      model: json['model'] as String?,
+      year: json['year'] as int?,
+      licensePlate: json['licensePlate'] as String?,
+      defaultOdometer: (json['defaultOdometer'] as num?)?.toDouble(),
+      isActive: json['isActive'] as bool? ?? false,
+    );
+  }
+
+  @override
+  String toString() => 'Vehicle($displayName)';
+
+  @override
+  bool operator ==(Object other) {
+    return other is Vehicle &&
+        other.id == id &&
+        other.displayName == displayName &&
+        other.make == make &&
+        other.model == model &&
+        other.year == year &&
+        other.licensePlate == licensePlate &&
+        other.defaultOdometer == defaultOdometer &&
+        other.isActive == isActive;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      id, displayName, make, model, year, licensePlate, defaultOdometer, isActive);
+}


### PR DESCRIPTION
## Summary
- introduce GeoPoint, SavedLocation, Vehicle, and Trip domain entities for mileage tracking
- capture trip metadata including timestamps, odometer readings, GPS coordinates, associated vehicle, and saved location references
- provide JSON serialization helpers and copyWith methods for integration with persistence layers

## Testing
- not run (dart CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e31e082d1083248a7e69ea741dd613