### PR TITLE
Fix Trip distance getter to return double

### DIFF
--- a/lib/models/trip.dart
+++ b/lib/models/trip.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'geo_point.dart';
 import 'saved_location.dart';
 import 'vehicle.dart';
@@ -49,7 +51,8 @@ class Trip {
 
   Duration get duration => endTime.difference(startTime);
 
-  double get distance => (endOdometer - startOdometer).clamp(0, double.infinity);
+  double get distance =>
+      math.max(0.0, endOdometer - startOdometer);
 
   Trip copyWith({
     String? id,


### PR DESCRIPTION
## Summary
- ensure the Trip.distance getter always returns a double by using math.max
- add the required dart:math import

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e322c6c9a883248721615d465f8178